### PR TITLE
Feature/pagination support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,8 @@ mod filters {
             .and_then(move |query: GetQuery, db: Database| async move {
 
                 if let Some(_) = query.skip {
+                    // If there is a skip query param, retrieve collection
+
                     let filter_options = mongodb::options::FindOptions::builder().skip(query.skip).limit(query.page_size).build();
                     let filter = bson::doc! { "path": query.path };
 
@@ -144,8 +146,6 @@ mod filters {
                         Err(e) => Err(warp::reject::reject()),
                     }
                 }
-
-                
             })
             .recover(move |rejection: Rejection| async move {
                 let reply = warp::reply::reply();

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,11 +74,10 @@ mod filters {
     use warp::{http::StatusCode, reject::Reject, Filter, Rejection, Reply};
     use futures::StreamExt;
 
+
     #[derive(Serialize)]
-    struct GetResponse {
-        data_type: String,
-        path: String,
-        value: serde_json::Value,
+    struct GetCollectionResponse {
+        results: Vec<bson::Document>,
     }
 
     #[derive(Serialize)]
@@ -105,6 +104,10 @@ mod filters {
     struct NotFound;
     impl Reject for NotFound {}
 
+    #[derive(Debug)]
+    struct BadRequest;
+    impl Reject for BadRequest {}
+
     pub fn data(db: Database) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
         data_create(db.clone()).or(data_get(db.clone()))
         //data_create(db.clone()).or(data_get(db.clone()))
@@ -113,7 +116,17 @@ mod filters {
     pub fn data_get(db: Database) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
         warp::path!("data")
             .and(warp::get())
-            .and(warp::query::<GetQuery>())
+            .and(warp::query::<GetQuery>().and_then(|query: GetQuery| async move {
+                if let Some(page_size) = query.page_size {
+                    if page_size > 100 {
+                        Err(warp::reject::custom(BadRequest))
+                    } else {
+                        Ok(query)
+                    }
+                } else {
+                    Ok(query)
+                }
+            }))
             .and(with_db(db))
             .and_then(move |query: GetQuery, db: Database| async move {
 
@@ -127,9 +140,11 @@ mod filters {
                         Ok(mut cursor) => {
                             let mut results_vector = Vec::new();
                             while let Some(item) = cursor.next().await {
-                                results_vector.push(item.unwrap())
+                                results_vector.push(item.unwrap());
                             }
-                            Ok(warp::reply::json(&results_vector))
+                            Ok(warp::reply::json(&GetCollectionResponse {
+                                results: results_vector,
+                            }))
                         },
                         Err(e) => Err(warp::reject::reject()),
                     }
@@ -150,8 +165,10 @@ mod filters {
             .recover(move |rejection: Rejection| async move {
                 let reply = warp::reply::reply();
 
-                if let Some(NotFound) = rejection.find() {
+                if let Some(NotFound) = rejection.find::<NotFound>() {
                     Ok(warp::reply::with_status(reply, StatusCode::NOT_FOUND))
+                } else if let Some(BadRequest) = rejection.find::<BadRequest>() {
+                    Ok(warp::reply::with_status(reply, StatusCode::BAD_REQUEST))
                 } else {
                     Ok(warp::reply::with_status(
                         reply,


### PR DESCRIPTION
Add support for paginating multiple documents with the same `path`.  Passing a value for the `skip` query param indicates that there may be more than one document.  The optional `page_size` param can be used for limiting the number of results that are returned.